### PR TITLE
Tests/add rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org/"
 gem 'mechanize'
 gem 'nokogiri'
 gem 'rest-client'
+gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,9 @@ source "https://rubygems.org/"
 gem 'mechanize'
 gem 'nokogiri'
 gem 'rest-client'
-gem 'rspec'
+
+group :test do
+  gem 'webmock'
+  gem 'rspec'
+  gem 'vcr'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    diff-lcs (1.2.5)
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.14-x86-mingw32)
@@ -39,6 +40,19 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -53,6 +67,7 @@ DEPENDENCIES
   mechanize
   nokogiri
   rest-client
+  rspec
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.14-x86-mingw32)
+    hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     mechanize (2.7.5)
@@ -53,10 +57,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
     unf_ext (0.0.7.2-x86-mingw32)
+    vcr (3.0.0)
+    webmock (1.24.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webrobots (0.1.2)
 
 PLATFORMS
@@ -68,6 +78,8 @@ DEPENDENCIES
   nokogiri
   rest-client
   rspec
+  vcr
+  webmock
 
 BUNDLED WITH
    1.13.6

--- a/lib/imports/constants_and_requires.rb
+++ b/lib/imports/constants_and_requires.rb
@@ -14,6 +14,7 @@ require 'tempfile'
 require 'socket'
 require 'net/http'
 require 'ipaddr'
+require 'byebug'
 
 # Created libraries that are relied on for the program to run
 require_relative '../../lib/modules/core/format'
@@ -26,7 +27,7 @@ require_relative '../../lib/modules/core/detection'
 require_relative '../../lib/modules/core/check_platform'
 require_relative '../../lib/modules/core/tools/spider/blackwidow'
 require_relative '../../lib/modules/core/settings'
-
+require_relative '../../lib/whitewidow/scanner'
 # Modules that need to be included for whitewidow
 include MultipleParameters
 include Format

--- a/lib/imports/constants_and_requires.rb
+++ b/lib/imports/constants_and_requires.rb
@@ -14,7 +14,6 @@ require 'tempfile'
 require 'socket'
 require 'net/http'
 require 'ipaddr'
-require 'byebug'
 
 # Created libraries that are relied on for the program to run
 require_relative '../../lib/modules/core/format'

--- a/lib/whitewidow/scanner.rb
+++ b/lib/whitewidow/scanner.rb
@@ -1,0 +1,150 @@
+module Whitewidow
+  # Preliminary extraction of Scanner logic
+  class Scanner
+    class << self
+      #
+      # Usage page, basic help page for commands
+      #
+      # TODO: Move this method into a Notification or similar class
+      def usage_page
+        FORMAT.info("ruby whitewidow.rb -[SHORT-OPTS] [ARGS] --[LONG-OPTS] [ARGS]")
+        FORMAT.info("Check the README.md file for a list of flags and further information\n")
+      end
+
+      #
+      # File formatting
+      #
+      def format_file(user_file)
+        FORMAT.info('Writing to temporary file..')
+        if File.exists?(user_file)
+          file = Tempfile.new('file') # Write to a temp file
+          IO.read(user_file).each_line do |line|
+            File.open(file, 'a+') { |format| format.puts(line) unless line.chomp.empty? } # Skip blank lines and whitespace
+          end
+          IO.read(file).each_line do |to_file|
+            File.open("#{PATH}/tmp/#sites.txt", 'a+') { |line| line.puts(to_file) }
+          end
+          file.unlink
+          FORMAT.info("File: #{user_file}, has been formatted and saved as #sites.txt in the tmp directory.")
+        else
+          puts <<~_END_
+
+            Hey now my friend, I know you're eager, I am also, but that file #{user_file}
+            either doesn't exist, or it's not in the directory you say it's in..
+
+            I'm gonna need you to go find that file, move it to the correct directory and then
+            run me again.
+
+            Don't worry I'll wait!
+               _END_
+                   .yellow.bold  # Error out because the file doesn't exist
+          exit(0)
+        end
+      end
+
+      #
+      # Get the URLS by connecting to google and scraping for the URLS on the first page
+      #
+      def get_urls(proxy = nil)
+        query = SETTINGS.extract_query!
+
+        # NOTE: This logic may potentially allow blacklisted items.
+        # e.g. query == 'user=?'
+        # blacklist ==
+        # 'id=?'
+        # 'user=?'
+        # When we get to the last line, query will be assigned a new sample from the default list.
+        # If 'id=?' is in the default list, we don't perform any more checks, and it may be assigned
+        # as the query despite being on the blacklist
+        # To solve this issue, we could do the following:
+        #
+        # query = validate_query(query)
+        #
+        # def validate_query(query)
+        #   blacklist = File.readlines("{QUERY_BLACKLIST_PATH}")
+        #   if blacklist.any?{ |line| line == query }
+        #     new_query = File.readlines("{PATH}/lib/lists/search_query.txt").sample
+        #     validate_query(new_query)
+        #   else
+        #     query
+        #   end
+        # end
+        File.read("#{QUERY_BLACKLIST_PATH}").each_line do |black|  # check if the search query is black listed
+          if query == black
+            FORMAT.warning("Query: #{query} is blacklisted, defaulting to random query")
+            query = File.readlines("#{PATH}/lib/lists/search_query.txt").sample  # Retry if it is
+          end
+        end
+
+        FORMAT.info("I'm searching for possible SQL vulnerable sites, using search query #{query.chomp}")
+        agent = Mechanize.new
+        if proxy
+          agent.set_proxy(proxy.split(":").first, proxy.split(":").last)  # Set your proxy if used
+        end
+        correct_agent = SETTINGS.random_agent?
+        agent.user_agent = correct_agent
+        correct_agent == DEFAULT_USER_AGENT ? FORMAT.info("Using default user agent") :
+            FORMAT.info("Grabbed random agent: #{correct_agent}")
+        page = agent.get("http://google.com")
+        google_form = page.form('f')
+        google_form.q = "#{query}"  # Search Google for the query
+        url = agent.submit(google_form, google_form.buttons.first)
+        url.links.each do |link|
+          if link.href.to_s =~ /url.q/  # Pull the links from the search
+            str = link.href.to_s
+            str_list = str.split(%r{=|&})
+            urls = str_list[1]
+            if urls.split("/")[2].start_with?(*SKIP)  # Skip all the bad URLs
+              next
+            end
+            urls_to_log = URI.decode(urls)
+            FORMAT.success("Site found: #{urls_to_log}")
+            sleep(0.3)
+            %w(' -- ; " /* '/* '-- "-- '; "; `).each { |sql|
+              File.open("#{SITES_TO_CHECK_PATH}", 'a+') { |to_check| to_check.puts("#{urls_to_log}#{sql}") } # Add sql syntax to all "="
+              MULTIPARAMS.check_for_multiple_parameters(urls_to_log, sql)
+            }
+          end
+        end
+        FORMAT.info("I've dumped possible vulnerable sites into #{SITES_TO_CHECK_PATH}")
+      end
+
+      #
+      # Check the sites that where found for vulnerabilities by checking if they throw a certain error
+      #
+      def vulnerability_check(file_mode: false)
+        file_to_read = file_mode ? FILE_FLAG_FILE_PATH : SITES_TO_CHECK_PATH
+        FORMAT.info('Forcing encoding to UTF-8') unless file_mode
+        IO.read("#{file_to_read}").each_line do |vuln|
+          FORMAT.info("Reading from #{file_to_read}")
+          begin
+            FORMAT.info("Parsing page for SQL syntax error: #{vuln.chomp}")
+            Timeout::timeout(10) do
+              vulns = vuln.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''}) # Force encoding to UTF-8
+              begin
+                if SETTINGS.parse("#{vulns.chomp}'", 'html', 0) =~ SQL_VULN_REGEX  # If it has the vuln regex error
+                  FORMAT.site_found(vulns.chomp)
+                  File.open("#{TEMP_VULN_LOG}", "a+") { |vulnerable| vulnerable.puts(vulns) }
+                  sleep(0.5)
+                else
+                  FORMAT.warning("URL: #{vulns.chomp} is not vulnerable, dumped to non_exploitable.txt")
+                  File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |non_exploit| non_exploit.puts(vulns) }
+                  sleep(0.5)
+                end
+              rescue Timeout::Error, OpenSSL::SSL::SSLError  # Timeout or SSL errors
+                FORMAT.warning("URL: #{vulns.chomp} failed to load dumped to non_exploitable.txt")
+                File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |timeout| timeout.puts(vulns) }
+                sleep(0.5)
+                next
+              end
+            end
+          rescue *LOADING_ERRORS
+            FORMAT.err("URL: #{vuln.chomp} failed due to an error while connecting, URL dumped to non_exploitable.txt")
+            File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |error| error.puts(vuln) }
+            next
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/google_search.yml
+++ b/spec/fixtures/vcr_cassettes/google_search.yml
@@ -1,0 +1,522 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://google.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Whitewidow 1.8.3.5 SQL Vuln Scanner/Ruby:2.3.1->Platform:x86_64-darwin15
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Host:
+      - google.com
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 300
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - http://www.google.com/
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 19 Dec 2016 22:16:37 GMT
+      Expires:
+      - Wed, 18 Jan 2017 22:16:37 GMT
+      Cache-Control:
+      - public, max-age=2592000
+      Server:
+      - gws
+      Content-Length:
+      - '219'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: "<HTML><HEAD><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n<TITLE>301
+        Moved</TITLE></HEAD><BODY>\n<H1>301 Moved</H1>\nThe document has moved\n<A
+        HREF=\"http://www.google.com/\">here</A>.\r\n</BODY></HTML>\r\n"
+    http_version: 
+  recorded_at: Mon, 19 Dec 2016 22:16:37 GMT
+- request:
+    method: get
+    uri: http://www.google.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Whitewidow 1.8.3.5 SQL Vuln Scanner/Ruby:2.3.1->Platform:x86_64-darwin15
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Host:
+      - www.google.com
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 300
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 19 Dec 2016 22:16:37 GMT
+      Expires:
+      - "-1"
+      Cache-Control:
+      - private, max-age=0
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      P3p:
+      - CP="This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en
+        for more info."
+      Content-Encoding:
+      - gzip
+      Server:
+      - gws
+      Content-Length:
+      - '4347'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Set-Cookie:
+      - NID=93=oJJbZ_BRSN3p4oIiB1S06PrZyY-OxgIFB3iU9zfsB0aUgYWOa99J-QxSXmuV9ior4iGljtekASRSWAvPzhvU_E_06Fq0R0_Z91odouWKFei7kn-R7xi4FB3rjCFBTwvVKhYo-JOiT2g7yL4;
+        expires=Tue, 20-Jun-2017 22:16:37 GMT; path=/; domain=.google.com; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAC/8U6a3fbtpLf+yto+FSWrmmKpF6kaDqbJm7qe/La6zRtN019
+        QBIiGfNlgrLsyvov+1PvDEBSlOwk9+yXPW00BDBvDAYDwKcHQe5X9wVToipN
+        zk7xV4krlnI/L5hLiGgggkuiqirmwyH3I5ZSLS/D4W/Me09DRpSEZqFLWEaA
+        A6PB2WnKKqr4eVaxrHLJJaOlHylVxJRVXibBEVfibJGXKa3iPFOh4SfLIM5C
+        ZcW8Ajhy6EslvI0DlnOFZoGS5iXTlFd5HiagL+VKSrN7hRfMj2miLBitliXj
+        SpUrEUsK5T5fKosY6Ngd9avkXllFtMLeo5IpSZ5fo0DQQiNKRlMwMGDcL+MC
+        dSL7JmR5HhQNYpl7ecUf4VTsrhqiBx3Fj2jJWeX++uHnE4so6LoTdrOMb13y
+        QqKffACnPmIxlGYPvRIMBv2GobA2HBp3zecVr2CMlsGVnyd5eWWYVlBoRRbK
+        uSrKvHCJYAPcq7hK2Jl02elQtk6llWf9xTLz0dj+YL0CP+UrTYpw19fnF/Oj
+        f328++O3dyy8uHj9MX3+6tIuLv/46b+P1Ovz39/DsDGaGJY5UxHa+gihadqi
+        bY4Ajma6PoLxsW5a1myC0LYMhCNzOrMQWrphAhyPxraAE2tsILRGY6SbmJaB
+        7ak5nU4RTmbWTEDbQHrgMtURWpOJgLY1siQcY3tmWOMxQnOqmwLOZshnNgLe
+        AsKIgPbERji2J6J/qtuif2qPDAltlDuzxiO9hihnZhuSjz0Wes/sqTkS0LJR
+        Lpg3RTrL0EcNtAScWEhnmbqgs8ypsMcaGcZIwLHQE8SMRRv0Eu3J1BLtqS78
+        AnAmoSnss6ZToac1m+mWhJIvCBR01ti0JRxNJRzL8amUY8OMCWjoYtyeCH2h
+        2xwLCHNaw5mAMCMCWgLfRoskHJsS2sjPNsyZLeDIkhD1sEa6rtsTAc3ZSMCx
+        ZdRwrFoTfTqFeAE4g0gRcGxKaE0shCBWr6HAg3AxBbTBPwKC3wCCohKaYKeh
+        myDYEgELH6ZxpNJlFS05K+e6es19Pj/ybR9CbKFfmeOjjSNXhXb9y2v3iGVH
+        zmbQHzjd1VMjJL776XODncSu3nyHrDq/cFsCOlhD2unf0lLxHNrr9Q8oojyv
+        qjL2lhV7eDjoe+5uX5+wOCCDwcAZUBgqaAn54m0eMKdkkPYyxXt4aPQ8v9h0
+        JL/+mmg3WybJfy4/+Z4CrVDMdtzt+EdiiA2Ez4nr1tkmyX2xAWiQs6ocslnL
+        IU0ekyuoboux6mBQ1Rusq/J+3VL3z8sSzKQD9cCAwQ3I8aO+P1hvWgZVDJn8
+        kZB+xlbKS1qxAVr/AXD6g5YkycMdoaqvBmo4WFN3i/BrmXSGnHjRJ+TABbeD
+        u4H1BeZlB93PWiJfXbTfscM+LT67nuNpecbQCBe/kpwG4oN6eVl11Q5Ywiqm
+        INXG2cnivd5OU7tlyRNdWrJ8uhecB0rw0ndpJ6QXx8am6w8w90mXSAsJ6ZjG
+        Hx4IcfyHhxPjAGzhoibokx6LXTJ4eOgDuvg+7i6afjBQTwy3i58IAojawN0J
+        ckDFXnbs1jjH0OFQFySSITnuhwBDll1B0iWDY/KMQlXjxj0fdt1jekx6PriY
+        HHvH7HgBrb/vtppUIgyc4V+yAoq1ivEK/NPrdQO+j9L3I5BQImJwDY6cUzVM
+        0nRubAYqBd8MmpVDW4/eu+v2+24vwBuUT1SLg8/uJ+j8XHM4MLZzctPNQRg2
+        u9OzTVY3WrHkUf/TJ/oZBz5345wGz5P9BbZPh/KBZjPQfJok/SqK+UBENt1f
+        3yomk6hkCw362d07WBOHRKwN/dT1ZLD4DQpfehxyThb2vWMDnN7/66E3uHGH
+        0uk+OBnjwd9h1etRrWRFQn3IU0MZKc/Isd92Si6Lwv30V+/zP4ahSjAExJRH
+        BIw4HdY10Smv7qFEOgw9WqqHIW4KkDChWuPx32xujIo7p6ABVmYnVV7MjeJO
+        OYjTAhYlzSpnI+jWEYvDqJqbZnG3qXk0RFA3Vnk6n+3SYeF4QpM4zOYlkm60
+        0ItU+AnWsN4DVrbCeJ7EgXLo28FsYTgdzUAUEjWydafIeYzOn1MPiCCDO8jD
+        HIMFqzioormh6z9u/itlQUwVmMA1kBtd1Z2UlmGcnQiN5tqEpc4tK6sYZrvW
+        FRjWFi8gZKp5whbVZkORkYq/47UwLGB+XopAmC9h0sokzljH+h0CUdLOD3Xd
+        72LAUKx0x4PAYuZsD2WxgwJFS3f8B5hiMbX1DHt5cK9WgUrVQtUiOccLmsbJ
+        /ZyWcJxQOc34CUxdvNgg7lp6AxybgxfA3tXJ/RyCJoc96TDMw2aG5xAiigX/
+        9E0VrNHUk9qnmsVSUJP6V6myN2RAPGzwPFRLacLE1HFao8ak0dTfaDcdH220
+        iiOvRraOHU3IAFpCC87mzceGpdLOlZTq5UlQhxC6ZJ7hgSzZQKau2jiYtOEy
+        tqcixvgiVgUKUs4NNPWRwxCL1wizJxECvg5iDovzfh5nwhVefufsd0ECua7D
+        UPhVV8bbuMRom0N7E2fFstqZwTiLQEw3skzxO9qNMsPYiTIxzR71r8Myh0Cd
+        Hy4WC0eiepBFrje0Q+jsh3YG+/WGziMMD5XO4cQZ37KvL4CNtkgU2p1ZOr+N
+        YcmyoOmcTAxqef/ZehJYIyn9EZZQ7TDEk7kinFHj1XLAzJ2VxL3EX3ez3AQn
+        HntB4WaKdubGxLnZmReRKTvpSeSnhHvejoMZY46M1rlMbIDmbMMXlfN9Xzm0
+        bbv+gaZTx+ZIb3nuKAWerRL1cJEkHXWfiihdMcyaRVerJVRwzTE8o7dXUOXk
+        cLDFE/YAIvAEDmtgLuwsjFYnjbrCx067MnXHX5Ycvos8hpN92dXZ2WaSZYVa
+        wZdcKpMnlspTORc1bgKs605wjli980XuL/m6YS+mf5v+6o2u3fEA51rBrfeJ
+        2wcozIOlXw1jP2+vH5I8KDToIOCDxCU8grjxl5UCXXhtMpQXQLiYFC8UHnEJ
+        xhh58uIB934sMo++4vIjUVLEjEPpTRPOnABsS+HooaGEujRWXOXxXUam9HpK
+        893HckPpt8RS2GDd1uT9gah14Z+z+QFRD1Am1NcNxaLX235rN5rwMbBtO0Pv
+        pouDzQ7a5gf4D8+NW8cH8a0SQ82ZZqFHzpSmjRvq2WmWe/DrKX5COYc+40xe
+        op0OPUCl2/566urLudWqLeP9PAWfhlHxLEpclvUq6kFhRs6Eufx0SL/FJ4UN
+        o8sI210+CTl7A13f4sKBDa69LpsuC4ucvYfh7yiCBt1DJC+9moOgNcjZH/ny
+        A3R+hxzmd8eObMV3HQIh+xZwvmdISuNk1x9xUuuSkrNX2Pwei6CE9brjDEGe
+        k7OXOPKYXCxYeau4n83JHu/9ac+qZMiyYS7uMvkQlt7y7E1egpDlmdIr6c0y
+        d1Dg6VDG2RBirw1IUbEqYtd3sUhsgpEXNJMBmrVaxphIoL87umhHF0+MsraP
+        fjN04ThR5eU92gDTL6eMtJzHZ78xT/lF4gjXPaDzmjxWAGAly3zGH1NesqqC
+        5Ma3ZBVkZFa5V5BcpZJXM33Pw9T3IclWO8F0ycrb2Gevc0jndUwVIAQm063K
+        JevhrW6cLZn7tIU7OkFuV+Ls6Tlp0KI6JMQOq38LQ9bsDYpSY/oM9yLIKnDc
+        SiCbuATqfiJyUBIWAdmmpCSk0ILsAScDOB/L+2MIOrGLucQ2iUjaX7uuxvy9
+        vbHG1tUqgtLmartb1ZfX5sy8s83m/rqO+KacNUUdrRhQ5JE6HgkQSI2jAvkS
+        pb4cIe2ZM+n14Kc/IGio/CfNxwJboWKXcJtTYnOjj7sTLMeEKT5LkloBl+hE
+        tCFe/boNaKVyK/ZiWJp5gR1Bq9zkR3LWyzxewOqqAjFUo0rfg7h8VdICTv/g
+        Xqxba/kxeBe4QqyQi8t3J5Y1sU8MotQPL3EQiLcVSVHjYVBL4ij5CqYc5vmy
+        9NkeSsMlKvawvXj1TW5eHD0a34YgCXg7jU3Nsz1LYrmu6C3DGq9TNbWlURMC
+        k+Y0pcDp44laiCh0iVeHaYHXYC7Joc5oVIFKqDUTVMa3jyaUlct69lN6l7As
+        FJOnj63GozdgBNStLpnMSBM+sGpqhbtHN7RGJLet/bsdWKC2Fm/7Ws32FKqd
+        XGWvGi/zpZfGFWnTZjej/l+FXhylys+MJfgC9nrpX993BF/gmvKT2L+GsFyI
+        ex0Nlw4UM4J6IHr8iPnXLHANR2FQlikwF+19DxRzQZ4HCSSGo+9Y0aySWkc4
+        E+E5gzSrBjNdZ83srLN2/xjS4JZCqg+u6psfmYppWjjNxb4L0/S8xlJ4XUjR
+        Dgt8wFxCKoMtIE/4Vzi8rpEUgSRzNeo/rDDHiPTR+BwzVOjdNm4Vn0+uPwNd
+        gu7dJl+8IuC4d5Buiq9jb3umskY/Oimct5plhjc0pJvvmj0XaHLMPV/hY+hF
+        tTtWr0LDxvMILK/u/VSTxwRf2D06PmyqDhpgxQHuxtXKIcT+932ZhyVN+a7P
+        udw+EfmnJeAxzpVLvKrCmmUHdVtOLnc2YMOYWratm/ZoNrGNsT4eTyZ6fS4p
+        ll4S8wjtPm7eP+lT2npQXmj4ags647fSwZaOlL/FXr6aTfG/ziHXQj/Cpl/c
+        O4qpG1PlRHksroBzrg9HCyhR4lvq34Px7+WXKEe+SQKOT9FbHxBK/YrtSmp2
+        9++97mp+kLvtPaEqb3f0jbN/KmuvceMsY+VviKZ6O32/CB54j3tAHx4OvIG8
+        yK1RmpOQCpHy4vLSeAFJmlYE72598fkmD9gzv8U7TxiCuS9Odip1Aw2yEPQ0
+        opt2LZb2el6v16cH7tYuTVjz8ODtdEpbt9f1UDj0CVHx/6FkiY8Cz3r1iwDs
+        gPWTAOx14klg92Hi+vxisHft/ZWT3d0XHpC96ho746fPws2n4ve9dtK4fIaC
+        wHw8Qe1h0y8ZrVjtwT6RvMnAoeJQ63UOqazx80/3F0FfajjQaFGwLHgRxUnQ
+        p4ONqg82tbFB8qXYPgR4Km0fAoB0Cax9JHC22K6/55uvByJwKFN8rhDugzBq
+        njgGzYe2iEteIQoG2Zas5XTVRNvVw8O6fQC70q5eLtPi/M5n4gS0NYAN1lVU
+        5iuFbToC8YGn5G18yKZ4BtGq1t6dXlQi4W7zWtjvPBc6Xdf1j4aAObwaws/1
+        n3ejAFpaVGgsu/r1Unt7G148568/3p+vtHfDFMe5dxUxNRiWFba+DAMExlC0
+        /vZh+ZccP5+/+GDr+au3H+3RP61Fzu+CC286YTe/v/H/pxxf0Nfhkfr/J3rg
+        bKcKKoTGIUXqu2sixJD5msBOmpE5npRU4ne/xZIkcywgyyTP0xMoUlUSRA1C
+        EN1U7TcHRBhdJE1PlHMk3m4TMBpzD6hNSyVfaEog65EvPM+KhiTlIUeN/NgD
+        NuQFHo6aigxE3AMJeRkH4i+KUkazOfQmWDXNycWfS103p4cj29kvqQAnRXav
+        gVEm/ngJunJ+jdpdiCpB1BHQWcAqhc4PsF7q6kRZUQ77WJrfQsGyKPMUZZcK
+        Chu9qHeIP0lzSP6TiIHzzplYYg6pHJAyUJl/CZ7Q5l6MitR/muXdyz+4wgG0
+        er5Xl25UkqGrpb/y2xLcBX3FjfQ+qAPnx3q0XADip8/AyYc+Q8cPmPAJwCq/
+        BoJfL9761oj/vfz47ufJL+Hz3yseroowePnPNygoQN7bJ1GZA+SjYyeVbFdv
+        yoJ2kcJ3/yjO4mobg9iqndJvOwVe7T1A3Wy6+edLmwm+wGrpNO7ip9JyZxgS
+        pyOemppLVlk/4IaGN6P4J3b/Btz04NpyJwAA
+    http_version: 
+  recorded_at: Mon, 19 Dec 2016 22:16:37 GMT
+- request:
+    method: get
+    uri: http://www.google.com/search?bih=&biw=&btnG=Google%20Search&gbv=1&hl=en&ie=ISO-8859-1&q=user_id=&source=hp
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Whitewidow 1.8.3.5 SQL Vuln Scanner/Ruby:2.3.1->Platform:x86_64-darwin15
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - NID=93=oJJbZ_BRSN3p4oIiB1S06PrZyY-OxgIFB3iU9zfsB0aUgYWOa99J-QxSXmuV9ior4iGljtekASRSWAvPzhvU_E_06Fq0R0_Z91odouWKFei7kn-R7xi4FB3rjCFBTwvVKhYo-JOiT2g7yL4
+      Host:
+      - www.google.com
+      Referer:
+      - !ruby/object:URI::HTTP
+        scheme: http
+        user: 
+        password: 
+        host: www.google.com
+        port: 80
+        path: "/"
+        query: 
+        opaque: 
+        fragment: 
+        parser: !ruby/object:URI::RFC3986_Parser
+          regexp:
+            :SCHEME: !ruby/regexp /\A[A-Za-z][A-Za-z0-9+\-.]*\z/
+            :USERINFO: !ruby/regexp /\A(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*\z/
+            :HOST: !ruby/regexp /\A(?:(?<IP-literal>\[(?:(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{,4}::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:)?\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+))\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])*))\z/
+            :ABS_PATH: !ruby/regexp /\A\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/
+            :REL_PATH: !ruby/regexp /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/
+            :QUERY: !ruby/regexp /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/
+            :FRAGMENT: !ruby/regexp /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/
+            :OPAQUE: !ruby/regexp /\A(?:[^\/].*)?\z/
+            :PORT: !ruby/regexp /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 300
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 19 Dec 2016 22:16:37 GMT
+      Expires:
+      - "-1"
+      Cache-Control:
+      - private, max-age=0
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Content-Encoding:
+      - gzip
+      Server:
+      - gws
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAC/6Q8iZLbNrK/QnPKY6mGknjooKTh+Dm24zjrxM7aebtZl58K
+        JCGRGR4yCc2MrdG/bzdAUuAhXy8sD0Sg0UDf3SCZywd+6rFPW6oELI6uLvGv
+        EjIa5166pY6q8hsEcNSAse1iNMq9gMZkmGab0VtKMi/4J813EcvfkA1VlYgk
+        G0eliQq4KPGvLmPKiOKlCaMJc1RG79gIF1kqXkCynDLnz3c/D2xVQewD+nEX
+        3jjqUwE+eAfrqk0UozCGlfKRm5HED5PNaJOmm4huRsZd+XOVMxgjmb/y0ijN
+        VoZp+9vhNtkIcrZZunVUjgawR2FyrQQZXXegBkh/57FR6KUV7igFXNChKhmN
+        HDUP0ox5O6ZAF1LNQhbRq11Os1XoO8pAecHnKYJXlyMxfpmzT9CcbVySaWcb
+        BN+vgcJBHn6mC8Pa3i23xMc9DFi6XRjbO+VBGG9hKZKw5YHP2wc03ARsYZrb
+        u0OBo5zkpoyl8WJWn4fcH5Ao3CSLDKcehhs30OCPv3fTzKdZtVieRqGvnHlz
+        f7Y2ltLOYCmcVK6tL7dpHrIwTRbEhUk7RpeIwxwDBbehz4KFoesPD/8TUz8k
+        ComiPUw35K0vY5JtwmTAd7QYTmi8vKEZCz0SFXsFhAXF6yglbBHRNTscCCLS
+        8O94zwnzqZdmhO9llwAxIFgqUV+bwPVicabrngwBQ6Eij/u+Tc1ZA2RdA5nr
+        ujyuXI6EaAsJD0EV5X2X1BaMXqZAK4zeLoLQ92lyGK4+Bb6sCpzjf+8FL60x
+        jQ9u6n/SmK/54Y023GpEQK9JHEafFiQLSaTlJMkHoA/hesnIdhAAayNk70Bs
+        OgNm9szJRCv/6X2OdS82t9APRAnjTaEUcNvk/lKWX6lzOLDAjroiA8vydajh
+        31wmbIZDt9rw44J4LLyh+OsmBGWivjZkoMC7ksWG4aHwopaYkzShwLE/Y18h
+        C7TjSq7Pjac/WYezdZqy0iYWumKjoWCfQva3Aaw0yLfEo4DnNiPbQ2DJ+5uW
+        lNwKWpM0i0m0LFm0rNAezjKaKzDZD/NtRD4twgRV7zAEQRZ8Qkl3G8oAzEMH
+        oQ43Gpcr+kaNETcCfuTM37d4WciotHDTOloQ4tOXn1PoNg5ppEShtsO/+yjM
+        AQnqo2BZYGhpBGMajHXRE7vPE18JzH2b/sOQllNA1Iqu6MMZmOzhDKWfkBvg
+        bKeUqnHAWghpNsXrSzw+nMGM0jXBrIhsc7oof9RMCbRJdm/cReBsBXgo9XsQ
+        Qmh2GCapm3WpwJDlJ9c7DHMFZpVSFsrn5W7V40apd12axlhHcYmAsuICxa2g
+        YgxKpZhJxlOIE7WuMUsyRNkze14lMXQRZ8z1tTMCnry+mxgYdFTCA4eQI4tV
+        zEU1aerv6uU7MMXVr+/8htLZ5SSwUybPFGs2AlmN5qHZJNlquhC7FGUIXjxh
+        iwEuhx4h14ZuTSXdNPIPNG71FTsoFF6obRzGtHIoRPeJuzwxDTd+N8hhFkxb
+        Rbf+XoSmgVmPpi3XnafeKfXHsXJ1W8cLUD95ehIcxlrg1xu/7KOzmWG4h7PV
+        zU9uh3JQHa/SPjhTkYn1SMt7KhWawGwTVFaZILNXseVKrscyeSd9UdEwm82W
+        DV8pWaPA8YvunwAfd4K/Ck6TUo8x3LRW767Dr05YlHQdzm7SL7Cqxgf8A7z9
+        /ZMn8YCHOlmVa7Gv0OVJsRAkoPuG2o9xx3m5hUGRGwGKokNoK9/V8uiBuLAp
+        XbrEu95kKeQ1Ze96vT6GFMhECcbQZSM4cG+yekNdMOM/+N8/c7eWLzzBfKFm
+        CTxRQB+J8xqGPynxSYy5uxtEAIRK+0dtAFO+XXyQ1uTdpWEhM76ioSiISjRc
+        O8WfMd9G9toruYk+nMcuHOWDOQzG5K7gs2XrpVOprJZGUbjNw3zZDgNN066r
+        n9C+m7m7r3XzzXbgKuQ1nU5h1ha21YEsu64syzTwQnt47VYuYIYXOqPf1lWK
+        M7eg4+9jh6dzJwEdclwYrp7+Y3NMZ8euNceELHdXREqMDL3m2goIby8IsxqO
+        T0jHnE8a1QWY8syu9wn2T2ZmJ36FR7hG0tWGo93xT17nWL6U9uHP8WojA59R
+        2RK3LRkEM7lmvpgF+YrHtVrcHPPAufr5D78Jn+/cNcSclceyqJHIL+XIXyQ5
+        yESLZ1IiI2Zk3azieOK38oLjUtwMdEUMuN0DZ7DNnO3WUK7QJkbuF/LoWoE/
+        flFbmBO96G0Y/cCqoFefLbeJa1JVegWG1R9vqoShLHMaGEVVs/q8q9R+MsYL
+        A9/OqzG6w8uKyT81ANvLGNxPEA8z6Q53HK+h9E7XWTPpLwRj0FiRsmIu3OGK
+        vQqbDDC5V8yblOC6q1+f00Y/Ga4jGPCeKUQbpnkEKUA9K+lMCOrlTQHp7bIc
+        brdpyJPaM0b8XOmCLIZEglIbL5KLYpxnJF3jXx0pCrfuwQDdaX2oRWVVsR9a
+        yKbG08PQjTankiUPgDX80ywC9enUNDpyQUEtzqiDHobXN7IycLle3+QNZcY+
+        DftBr6JtM9+uayCHZs0wxSunxklAWXUdSzJuy7Yosg7DdYu3219dORgE42HW
+        SOGXjajbUWthRdkwDYyeb9wGqoEgr30y046VzaQE8L1IvKrQBHJMMC1jaGHZ
+        i0P1EnWAp40LWN07oH3IKaTEMW7ap0wXuJNvIb43hoveVQoBrFVYH4dO5/BH
+        EFcJ9y3F6mQv68xqXbyw2sSi8Fh5D29Cn6ZuetcZAtAFf628LqxNqzqwcNpV
+        3RxHYIHvKc3ytCGexcmeB2jI7z6lO7ZYh3fUl0/1pKK/zF5Ms3n8UwJVZGLo
+        VMbFP11Uds0MZfXk+akzSbrGq1lklk5bxD/0/DypkU41sFZtHp6UhawUw/ES
+        yiIYJ1F2OBPHB3iqXJ2N1SMEt9XOyHsstqvBfLvyElaDmIoafZWQY7UqeMIJ
+        Fj5B5Um7WqvvhLNaraOKbUcXVHLOp3iVSchk2j5k5gnQLmJvGWGVTObzeZPb
+        TZvvOkmJ82hzddTuIqc3GouatUxEMnAp7vMcScfKtKhOf7vxteE63raYO/Si
+        NKcrlyX7ZnV+to4g1mpn7roVcuVEsvJShllWDA1bq6WUSTO3PovzMl4shpaF
+        OYScRSxLr8oNCwvtv7odrXTW2lFTNHjKtQYWVrat47xjgQ08OakZwh8tG8c4
+        rePeybxRA094JQ8SE05hbtdMrqM+7VKU1Z//djXCG9nZ17ObZTeXvnTy3Qx+
+        8p7bRJRyl09FxF2XEnQT8jJoWp8lWZ8w47ZR146gpLNV7k4gX1z9Gvi1HMqN
+        oIL55m3VDvZlf7jK77yvKl/dIrEsDXwUFjS16p1nOnn9gHNsNXkJxgAqBCle
+        eeTPE+DqrghVxa0U00RP09RW/975Eji37E7Qmsniia1UAu6yqFc+94PFVlG6
+        SU1zjk8L+0qSDjK6paTjsO/oab4bmTIwLGTGwB5LNaH0xAx/1mzxIB4j/cBK
+        c4yEA3M8kVayqpWmk+6VFP5sif8CXfoREvXvW3SV/NTMOI8mySPOjnHVEnJl
+        GZj5lmS0fQzbmX8C9isgaX8SC8C81ve1czd5jfYZneKTPKBl0z5/2GQU9lI7
+        7KtSHvz77e6NezB9WT1w5ebW9GH6FxjU9sL8wdNRILqgXjL1gaic44GfpVs/
+        vU0GMU12jVJHPkfB08h2mut7eLWeB/Bzr64wUT0ZE3GN7FjaFf0+8ycDdws8
+        APvr2m0+3ur2zQBYONH2WSqlFP3sf66rAGRZ1ikJCeLL3eMTduNUlChL8iZq
+        MLK1u9nUTqLWBl7L0yF6glepBjOerKHt4XsR+5IjRv2kctxItsblpBOPrOb1
+        c3lDejovnLzZkft1BHnhxaxZuRx/hlWKvfsx6JgHkAgESWS2cFF2aRY/3Wub
+        XR5GsL3q2FGvkJayb2Fy53gtu2sNouMFg3eDPCBgCGCfOUXvZoiTZoU/Stc1
+        fg2N/hKCuXsdssH3TInTz98BLwhiZaYhVF4uc0KihMl2V506ZEU9egQrugTw
+        vtUJ+GUZ8JnyYtWhiS6KEn5q206/ut8WaGUimCJNC1JRATuOGI4l5/IW9jFw
+        M0quF/zvgD9MgB0v1qm3y0sPX1TsyCn3i7SUW5vWUpWpqCJ5xuPndUbKNjnD
+        q8MCSqzzpgHhwW9lrDrntStvcMAj64KrBNJBssEmI34IfrwHnNDOxv5cX0Oy
+        M57ZM+r3lx1T8x+dmf7oxELnq2kCjYYkK4iC/xAuTVtnadwrcPY1lvZKvF9A
+        /GPb+rZZLYdg6bP5MaLj5F3Oq9F23BDIKmnPjimOLRyP2xFzvlXC1mRGqP0j
+        Ej498ysSPj3x/yfhAu+PSrhjW2Us5SPfKfoKXUv05nriujMuONlp1DLB41KV
+        2UOua/FaRxoUafBCNIO7U/6zyDF8uia7iBXudNLlTtsuBXzoF30lp6Osh74r
+        yFjfH8es/jdHSUuWZI25P5Dc1+jN3dBL920sncl1WZhM5Oqfp5yNU6hihUnH
+        23rHl/28LNyyq956l3i4v15/fwtePr0ditdGnf3185eLR//837u//vX6af6P
+        12//8/ft25dx9kv65I9H2vXzf7+BYcOaGLY507Cd6xa2UFrxe9OC1prpugXj
+        Y9207dkE27ltYGuZ05mNra0bJrRjazzn7cQeG9ja1hjnTUzbwPupOZ1OsZ2A
+        H+Tt3MD5gGWqY2tPJkUr7ue2ZYt2jPczwx6PsTWnusnb2QzxzSxYg7cwwtv5
+        ZI7teD7h/VN9zvunc8sQ7RzXn9ljSy9aXGc2NwSe+ZjvfzafmhZv7dlYtHNs
+        gdwpzrcN3Spbm7eTqSlaG/HYps7x2KYx5v3mlNNrW4Zh8XbM9w/Lj/k97Jff
+        T6Y2v5/MDI5/qnP+QTsTrcnpt6dTToc9m+m2aAV+2ACfb4/NuWitqWjHYnwy
+        4XjsqVh3DhLmraFzuPmE0wPd5pi3oANFO+MtSJC3NoefI6Wi5XRCO0d8c8Oc
+        zXlr2aLF/dgW+KD5hLfmzOTt2DaKdqzZE306Bf2CdgaaxduxKVp7YmMLy+pF
+        y+FAvUzezoFPvAU+QgsbFa0JdBq6CQvbXMHhh2k80sDwAnyDeaFr17mXLx55
+        cw9Ucq2vzPGjw1JY0fD6l1fOI5o8Wh76vf5StrYCIPKc9x9K6Ch09PL3hrLn
+        L51qAunv12nWuyGZ4i7J+XnvAUGQJ4xloQtFyf39g57r1Pt6Kg19tQ9hrE9g
+        SPiW31MfylXKdlmiuPf35T6fvzxIK786tbST7KLo29ePvraBalF8mz53JP4I
+        CP4Of75QHafwTuAJebk63GYpg1oyqjDEUXu6gtutIG4lCKK5/T3LPu2r2b3n
+        WQZkkr72wIDBA6zjBT2vvz9UCFgY0/YivYTeKs8Io32k/h3A9PrVFKgma4tq
+        nuZrm/6eOEeAP7NIGlqG656qPnCA7cBuQP0SM4Qlsp9WkzxtXf0Ol/T9+oPj
+        Lt0hBGskwsFfUM34/AeBUM7kbfs0oowqOOuwrHn98/Pa7fCGRh1dw2jX3QvM
+        g03kmecQSaXXF8ZB5geQ28kSQaGqSqTl9/equvTu7wfGA6Al558k9NRzGjpq
+        //6+B+D894VsND2/rw0MR4aP+ATQWt+pKTmAYi+9cAqYC0zriQMrqiP1oreB
+        dkOTFThjtX+hPibs09YJzz0GkORCPfeAxeqFe0Ev1nD3+e64E8bVYDn6P/ER
+        SjhkNGfAn/NzWeF7uHpTA1Wich3cAyMXRNtEMb4e3dcI8KZfWg6pOPrJ2Ve/
+        7xoKXoK8J8PQ/+C8h84PBYYHxlEmH2UfhGpTF8/RWX0cbnd50Hv/nnzAgQ+y
+        nhP/SdQ0sOY8XB/mHPpDyAGjHgvCvO4VhZN53/aTXsU4yB+vwbPAeqqm+l6k
+        9g/V5uHWeWBId17NjR37H5Nef+GKXRHYUQmleLAkGOCDI6g8zXmAJwjCFxLQ
+        E1CxIFyzHjo4MPpDYRRQlj+/AVf3KswZBZN83POh1o+hpzXUU5+9/q34fOgV
+        0ESBKg+k39dO4CpJ50D9RQnFGPECDliZptTXU4U/gGn9BvchIxSpYJESKuLb
+        Kf7d09/khohe9aoJd9UUGzmyen2MGOD9Cr//PKLIAc3nMUSjEOro5WboBWHk
+        Y0zIhxFNNixY0osLgTFw5OH39MNyYFz2VEW9CIZeRPL8dxLTC7jvD/kBxWtw
+        nErzDFgp7D7oH1QsZiCU+EOeBA+LLBukU+9AH3R0Vz012JIYdO38hqK1rxsx
+        zieMDGAI49yihYkvedBAp1WBEhBBzRGrHzTPQQks3ff6hxAUDyKoN6R31HvL
+        +Xt/L9/1VGQIuBoA7lcqeA3eVjANSLw+aiOoYzlwf3+TQqWoO45DHnvvrz88
+        9hxsFqIB37HgLTmpFiPxWRw+lVM41x01yLOtqrgbXrg4Kh6mw3+qIuoQUac4
+        ql528HqE30OFIrrw7urSD2+UEFyyS7KrS/zCAZYp1ti4xlX5BZp7pVySY3/x
+        7Vvxdd/tbRWEvDQeCZf/OIgcmpwzN3bC3AvO83SXedRJN+eMuJBKqFc8qOaX
+        I/Il3DHZ5jJyvC9RI55IvfoNur6EJQc0qAkyGhmFrV69geGvbASJxDdadq7A
+        IF56yB9zFIZ69Ve6ewdjX8ECyUSNnOQ2D7byZhL16neA+Ro9MQmjOlvCaCT2
+        EqtXL/D2ayj8DErhGk/49FS9eoYj7encrIRbaj60UBu4GxoRJiwa0WSUbnFG
+        PgK92139lmawyO5KOc/Ix126xAUvR0IFR6CWR93EHF8RGow1e6mn+JRR6G5S
+        7TJEJwn98ui6Gl13jNKqj3xRq8EkWZp9QhpAC4TI1Arz+Opf1FV+ETCcdffI
+        vPIb0S00FDywR/P2zLeUsTDZ5MdpDN+NZ84KbFVscjXTGxwmnpfuElZTprc0
+        uwk9+ioF6y50aguLgDAdlu3oOT72CZMddb5ktw+tn0P60Hr28u3rAVSa84Hx
+        0JwGEfTQBH4JM4a7YAt3H+FH8dnqQ3NiPYMulyUvoFd8wfrQ/El4EBjYuDfQ
+        b9QoDzcghaRb8iVYUCieeBb0JYjiYUQJUnwKBQEjBn6LwzTuAj0aRcW5fXVf
+        vGbJ7wtFb50b4Ze6sEUWFMqoGpaJUZkFcudkZrU7zZl97Cx+jDgy/OeXXp0/
+        4lOVG340B6aWbo8uWi2f3OFn0sZRXUe31C19SLX3H3r4PpZeN7eOB9Pz1rN3
+        tdoPxBP8NtlRX6QQWcrvln9JY2QWFytuVchjxPwOWiGAofkBi+p0V1JofPkA
+        ePFV+XK4603ahb5sPL6BnISnRcAtoeWCApZjxKQsSOHmxfN3qoLv0DnqJldL
+        9fl+tZFPAnX5G86mGvmyFqv8iWO17FfWauqNeLqnVio4mRyZKU7YCz06pdrF
+        F6AAxR8DSng5IvAZavl5eiXytwUn8fwT/McWK1pHTTELQbDcDVKcHpM7kQeB
+        iPWxXfL4oyqluWpNR7hhjDgjGrpT45ifqw0Oui70QErI0kTqrCgoNyw2gI6q
+        3EO+c+MQd8HjQqmgLv9i/4ctamDhI8GBUfuKQ3pjx2qZVRWKRoKIivoTvBGy
+        EuQEUUUn+oHif7/Aj5zVOiQ44grUaEGO0LpOGOvVeeLm2+VxJ/8FAAD//9xd
+        eXPaSLD//32KWd6+VFIxpzmMszglDhtswAf4ymaL0oWQERqhEWC82e/+umck
+        cdqxie04qUrFQhqNpnumf93TM9MNw/BBtNQWRt33thLO7RiMrIDGDCYWOt2z
+        F3/jjkCCm+oIblUjuOcssgez4hW1EcHnkb3QwvHfPITyAbD6huywEKi47fI7
+        eeB8EqoVr4CVhSS/MnURlIL/cNyBVjDHNuO/fMvXsgfid2gS84dy4Ypf4Mwm
+        IffOjyoT00jn9bFTq55Jvav+Xa1xVD3tNcvFxGlHOq8VT+dN5zdG19jUNiUL
+        htcF7mR/i2SBmb4pWZOZQf/GiGI96mxIVUmK7LXgdQf00YaUfX9+hy1aoXtG
+        7WiwjuwNaDmdTSHfWA8p/U2HXQmkqUhpf56qGW0/jsfPU49QIdytwV04N6bi
+        wMiIBL9MYPhIFeaEprM+7tny7bcwVkqnONrC//yDXMF1EBVExt/iibi879RZ
+        v6gsHB7jR32XTwQ8/jjwbJnXt9S4xSw2J68x8MGkT4WuHdBYwlQhx2LCDFZ0
+        CqbMVlBioGu+AatoPBrR/ENP8fi92W/KROmh5nZAGdpTgq7xv+L43kK50axc
+        b37QD19ssHv+WGcF+OjuJirRmZzXygCyJzLzSA/qFSP+Idq0n0HbJnpxgbZU
+        mpPHvk/f5GfQN/lR+ia63v8+bYOfQdvgR2kbwLS9933ipj+DuOmPEjeF5s1o
+        i4+skMrHwZJldriJTnyX6v08gpLJ12aRZe4mf4BDF7qrwHRosI5B4mphmrPe
+        8zM7Qrg42WG+Gpg7gAecBHYBWmS2MonEViKRmLF13qmK78x9IThgGNlbKhaq
+        2+CGKV6k1kJLDHRKbQe/3Micewpmy9AvoeOaaXZsYKouZbTrcZNPt6MjBgxR
+        XNmdQoHkTjKdzcZk5twGjD9/POP3DeO8IUnCRGRGQdo/vSk1K+1BfXhRNCnd
+        Oeo4ie278qRZVL9klIszCX0Ge+etylmnVuYrHe/buA9MVr1o67T+gURJo1Vu
+        4p+g2b5na3uxMxb7pj9e9ggFB0i5FYQnyfc2Y8pfcf7ygpVqF5VFD8/i9rUI
+        obZqmWq/4C+BxXABzF9nivCNg1H9FubXGq6vdWWL6f7dHnyROiMwy9CFHMHo
+        G3yhj3ulgnU3+PG9bskVE7X9tiQt+Vg6x4k5r8eygTofNivwG0eWVxcjxKWc
+        y/x61r4oQgVK2AxJ8EDHgjH/BX6vjlN0jeuKKqu9YH0EUcUPJrnoKkcHOC+4
+        W5bH1ydd7Wg70z/c3axj/y+VSRWX3Okzz7vvP4cr1cOvWnZ/A/GoScbVGvG4
+        7Qz7rfGXdOZq3O7Il1q9aVSvx3VtnAQMKyGB2jr19SBDF9YBH4DgYYG7jHRt
+        Q7Z9XMJ80BeFTSC7OjGuGzhCW+bAtFZ12rwrjv+/4Cz00CvjHxiMkTZIFunq
+        sjdydTIxQbkpOgDxAKYOMBWwiUy6I/4MphIMNz3Q7gxeCMAO+Utx9/4HV3R0
+        N0YkvoI8YjDdJt581VAV7k/S9LFuUQcX98mEuv0tAqJMQHZs9MoPqGZ2p8J3
+        F4vFAnGbLbeszHofDecaVVmMn3WCTuId1ZWHLApfj3ouHSmWznqU4vJWfAq6
+        NYpdxaIcNwARgxfjk57sRU3GH0dnLqSnwb7ckCpL43pfLXU6Z9JtvdWYWJl+
+        Il2sXhpSy8gmDoDES/gqAWYC/PtDiMM/sm7SmwIjR5ZGamQCPYpshDLE9D6T
+        b6Tmt5tUdcshJa6dn1sn3M9Z6MI5ZuKvJfb9sgri4E4q/rYKwrqb9i70kZzX
+        z2cK4mXk55UUibYqcAcnqllLjbRJliUS02rpKD++Pop2zt3TxOmqInkkrl7T
+        ERnI01AQmQ4SGsqgvCy/72Uyss3hSCd844CJASHNrgmXHgr8hNrv/nc7/8kT
+        EKv2ZNvQPwCSMk+XNQRi6iKuQt0wUvgeB0Bwrwe4QHS+74Ic2wjmMqMcXjUq
+        MBn+4QeeHWdhmJh2l4pJQIxNFZn5WxIAfeJguZtqHEeP/2SurKZuZ1O5ZCyZ
+        ySV4BO04X2di8atMLpdKxeDWZlDbbUi1pZ6vDhz3xPSUpiaxzGE65556nndz
+        I10a+wa3sOe7KEpavLHPBZpP4Q/g5Yz8XxYqa2Wp9NtCZbY+PLsdls/qUd+W
+        flEReCW0NFdl5iBaGZ8UD+zquHlmHJ0aSmmnPrXNzkAdGK9odr8ca5/RNL8B
+        9m1umi/iT4yUdbG3Eo8xkDO+GxvRWye1MrFHAwWUBSgCvMEcXUXtoQltQsMH
+        6sjFPbVCiwhNY/MHKMmcVwBytiffxpYU1Pu/+Q9cjP/nQ4ycyC5ceWjKkfDB
+        sxrpuM8L+lofy7aqgzTy7oW+MuI9Ool6NNoFMY9y+6Irq7pCaZ9bEqYW30w9
+        WA2psTzUO94wejs5SV9d5U5OBp1L5zpKW71kRVFgxlWlE9Sk2A6C7SD7fjuQ
+        defIFN81E4XO8gkhuOOuIbt9Hc0jUgR6ntsGX8s4VCDf5dsvq1cOb6Tyb6tX
+        jrT+Yaqtntfb6ZkJ/gPS8Uqag66KU6XnqeUTVts3Byn5fKfXvvuiOaViNrV/
+        uMZh80iQbICNndkiqUQyiXLHTViQufuFk6NerbxFbCyCxjUfwCiOYBrzso5L
+        u6alE1Aj3GFhUwGYFgWr2+XOCvasYIeHAhO8D3FuFeczIr8RcRFf0bzTN/Qw
+        uA3pdLkj6rnql6MkvaQJJzVUoVeizoj2evusCx0hYWNIM/wsQSwjJ6I5z41W
+        j6P8l0Wmelmq/LbINK6Pkju16e1VQ5oh0+M69JVAaLQ69g/a+Zt8pVWhuUO5
+        pGdSRis7cUdVPdq+kX6C1/hx7HpGk3QMLPkBb3GXjGx5LMPLmLmFCKyA1glD
+        9MCFZxhMjW80JfAaVU2kVzgjsAhSwl0ZTDgmBLLKmubqjC1bnWR3+R3fSTLz
+        j/huazN85ABYlaht63zz9BZRRh7/xIu4koGHsiozj/lHRkAMY07PiWNU3xFj
+        cXTU2LrF4gaewZOtqP8AWhY3XBRcI/B/cf8Zk8d4y/RQhwc2+Wa4f9uQzpfH
+        /sXO9ui23DgcHH85PpavupNEL12qq6xqAsUHoj3rPMuiWcTknqygWWDX1gPy
+        n1stLPIVrddHc+uX1RWNG2n/t9UVWvRkR7m56Lp3iZmueBXpeSVVk1gVt+pN
+        ybt1Os0j59Ip7jf6Jb3fdmS1mTpvrFE1j0Vg0pPHeuC8ZUCYWDeDXpQDHzG3
+        ennQOe4qaFF4yt9aEm0XLGCY/3P/vEhRseXDMa8wcF0jq/HARA8xV+VwPofI
+        phZAhO4DBDeqXfq83mTmyWo/2MTIxwuAPRNH81Lbme2dfCYf1y0Kd20vCpoz
+        aogjajg4fD95lHbD8TIBaqKqq8u8jK1P+JPNoDbVkK6XF/FyzcuDtJy5uZDv
+        2HmT9U7U3OmQSeUvh9D3OPDHugUIWvFbTI7PGrvEbzJ5NxxR75Opib/zbn5x
+        Z7Ef/VJIEeFMfx4sXuU44vBTWUxWePzLAnTzTjr4bQG6+OUummm3T8p2LXRf
+        v47MvRJAZ1aFtOolM+1oslO7varl+/XjVv3K6BbZ0Zmxs2bh78XmAq/D5mec
+        Q2SBlZvPIdBjs8M9Nul5jw0umNo66BZcLOX+6ylxXJhIuFPS16ehc4Z7IwZU
+        061dUau4o9/C6NYY+coVWAir/6Izx4O5AFT8p1/dEdRWIFx9LQEp3vqEGEr+
+        e4kV0Yc6OpnLZjO5TDY+WxGPylEgnAcCBYCGORYaPj+02yTfkNTlOUHKzezc
+        pZWc1soeX06P+uNtNXNaruWijUlk7z4mEZn4TUMD4s9Oq9Jq1Y6bf99X/p/P
+        uHyK5JNjn/6XU1MzpqLCehw/f1mldHIjVX9bpTS+yZfa06pmne88Sik9UYhe
+        R/P0pFWp23dqZwcX9Zpxk5/2e420pFvXjcsaA+B+zb2Lz8jL51MvvSLwa3P1
+        EoIRyJpO2Aj9QYZFFdkiY5Q+3J4EtrKpYgQGirsZ8VQxQxwLX4T5DMymxFxI
+        0YmsqkCrjjmr+vDLdeUp49OqpfkUTMluRszDTTdcXtBgl0X9cOO1Ncp2ZieR
+        TedT8alppqKypq0xEHToUocybyN10qs0JGN5acG7rpiHd5faJFFJ98dn1RKt
+        b7eaw9FFAmi6hpbsEknT7tW+YhYj2ga8w7b9NM3xCL79smrjrI07E35TtVGf
+        XF1S50v1bpx4lNp4iqS8ks6orhGtO69/yY7SZroxvYg6VyPFSUTbKivr3c3d
+        SWBSc6jzwMrmPiUVLOsYicfbFL0RII7QocSihhFsJsGBRv7klwXyFSR6d/dP
+        2XGi7wzvE2cbXnDkFE56b/pprj5TC7aizNfJq6tpL4GQuFKOvivqcsqw4/3e
+        4y7DcPMK12hDC4NQwyDZbA9J76gh9Vc0/VlZvR6edhOVVCWBoJk28tf5i4vK
+        sbF8iOf9B656+J2m1Ki8/8C10mmdiD315Nv8j/YI1JcJau0ZfT5ruLUI0g8y
+        7ZdFw9addPjbouHl9Y1SqiUHhyenIRpuKBWvBH7NVTGqSLaSTLappCc7V0Nr
+        5yI7dKIn+9UzrfSaBvOGfHtG4/gYeLO5cdykY5LKr26XufbVAIZeA7MLSYCh
+        7vJFP9vjhu4iToWBTxGwENhXdheGy4S1MulSfx873yYYrtgCa6aoALojS9h9
+        E50b7cLeho9/VyHE6Vqy5yRVtaCTdwHpesspa3Orce4XkWop5+pigrckgqaI
+        eACTB398EG9+TlBAXi3EdXt8YK4wBMPi4VonHMfFgboE5zzBzA7HcvnpIxxG
+        60cxWj9Cd/IB+3GjuDjJ01rt3DTECVWolYha+SDxzzYIvuDQddafIl4bRy0p
+        Aqm9CgvYlHn6oDO/JPRUFkyN4jIL5mpdZcF8ZL3X6nR/oH7EKb2DGzA2JPai
+        ZJQiwbBHCQgrfKNdHYBTxwGMU01HtjobD/aLllHmPb220rfR0UvSjYnkPtIu
+        l/KN+9w0KutkHOtGG5/X/Ua7H9nxA7J9MTX2Q9LfjjTP41doiWxI4mXJOFiB
+        r7DSe+hdCn8YqmIMwdClFI80CD3oM0ScyXhSmFOsCqMR8Sh+i4wFTvu/cRCF
+        VrmyZNirGFxxJT7iLMlRNMVzV/oBD1OiNwLzY09QHsSTelK9me35ehOL9SYX
+        Kw7t1a713OFCdLOwPjuPGCme7HqFZCIYNs2nci+Xvo/KlBgxb4TE1EuQuP2m
+        SNx+CRLTb4rE9EuQmHlTJGZegsTsmyIx+xIk5t4UibmXIHHnTZG48xIk5t8U
+        ifmXIDGZmKdxZrYs5C4QeQ+5YfPTuTBvHdzfyCdxJ5+d404uOW8b8XoeCJwu
+        pgxoXGHQ2lsv9NnK60zTmfWtloU1qSATF63wZJ6nxU18mqPKt1XnDHNZ46fv
+        tM6Psz6yJ/mVEeYnL5HnpwAjB4P0oO9XPI4rph2XbTbR3Zgz/SyuCsntdDqX
+        n306jMiJEV+C1Bh+lR6lFot3dV3D/oAvgIU/5QeiPzsu1UaqV9MKyXxWTC1G
+        ujtdSx1+wtZIUE84J5hfAQgY3bXWMxpDsZPw6mGeR/ZEtH7hGMSQ/Ut0BVk7
+        ZE0wFfOGzjyJJy41XHnAll5iIgcFvFHEcEU6Y6Tl755eLhrU71DLVE2dxWGu
+        P5bVKbTsRFx97wWgaIDZRNr4977WYzg8PItuBaHxBNkrgXED0ODB8Xqs42c6
+        WJwYzUsBxq2dScPDqZuWMzXpmBIKvnRfds8weWGlRgpBaZHBcCVbFCZ7i8Rv
+        b1i8E4f/+gW4jPWcmG53zlux5tioSax+Ma1MYsfxQYEpnZ6+pcUBfG7iMC7j
+        XuFOBS66rCCV2vkEPWhe5LcPd7qU3Wo1JZvRh1cN9Yubrsl1g0PJo3JV+e2X
+        Z0nDZDWmvv83Ihsw1HdxnWkros5fW5h1N7Ib6emma1E6QIe/g/nFekERrTf0
+        wmsGReEpII5/h2cb2I3MYknDU5Mp8HZqZytyIw8iuwn4y6jtBK8MmAHV/BtR
+        TQWqiZTQv038LAHwiSm8Eimb/NQrGeiyvQt3LbU/hdu1r6NEIpXFfRYDsq/r
+        Fvr36yN8CGUGWF0dKrLJgLqYcIqyPrauxuPwc8SAmw50HdzkPnyBRmQiszBO
+        GCZFFhs18WPbJX9sf40EyWi+RviDylzuGVEyLosH4hvYmDNeJ2a+UkxsiA9n
+        ylScL8MHSPVuxE/h4XPhv62IjawW/KJjF9gF95whlAxc8/AuNMvRglJuF174
+        O7LeXw2FA99m6NjEjz/g+Fp8PPOcLN2fOYSx79b5D/0XeJF/4FqFJicTeKFH
+        djPw16N9oOu81lR3ttnd6OJ4P1M1pCuPGRPH0MqHjch/Hx5MwraYkVHVaOFf
+        P/h1Ykso5MR/K8n25CCxpmnbunuJxbaUhXtVXgdmpfxD/vbtD+UDvqYGRYLE
+        dlvQFaVWK1miA0f2IoWCilIAlw2q6Z/VsJyfBW5XjSGCbckFLSaEL/h08Nv/
+        rPzunfLu3Xv5j8KMrhin5ts3ZeGmoHWWYJGnbgOuw7+4qBLTOH5+5+dwVMyJ
+        n8RRMXs8ieNiKkkAv+VUeUsIGPcxGOF97/8BAAD//wMAoVtOcJikAAA=
+    http_version: 
+  recorded_at: Mon, 19 Dec 2016 22:16:38 GMT
+recorded_with: VCR 3.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,7 @@ require 'webmock/rspec'
 require'vcr'
 
 
-WebMock.disable_net_connect!(allow: 'github.com')
-#WebMock.allow_net_connect!
+WebMock.disable_net_connect!
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
@@ -20,6 +19,7 @@ RSpec.configure do |config|
     File.truncate('tmp/#sites.txt', 0)
   end
 
+  ### Silence stdout during tests ###
   original_stderr = $stderr
   original_stdout = $stdout
   config.before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,34 @@
+require 'rspec'
+require 'fileutils'
+require_relative '../lib/imports/constants_and_requires'
+require 'webmock/rspec'
+require'vcr'
+
+
+WebMock.disable_net_connect!(allow: 'github.com')
+#WebMock.allow_net_connect!
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
+
+RSpec.configure do |config|
+  config.after(:each) do
+    # TODO: Remove dependency on tmp directory's existence so we can just FileUtils.rm_rf('tmp')
+    File.truncate(SITES_TO_CHECK_PATH, 0)
+    File.truncate('tmp/#sites.txt', 0)
+  end
+
+  original_stderr = $stderr
+  original_stdout = $stdout
+  config.before(:all) do
+    # Redirect stderr and stdout
+    $stderr = File.open(File::NULL, "w")
+    $stdout = File.open(File::NULL, "w")
+  end
+  config.after(:all) do
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
+end

--- a/spec/whitewidow/scanner_spec.rb
+++ b/spec/whitewidow/scanner_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Whitewidow::Scanner do
+  describe 'usage_page' do
+    subject { described_class.usage_page }
+    it 'displays usage info' do
+      expect{subject}.to output(/ruby/).to_stdout
+    end
+
+    it 'displays a reference to the README' do
+      expect{subject}.to output(/README/).to_stdout
+    end
+
+  end
+
+  describe 'format_file' do
+    let(:test_website) { 'http://fakesite.com/' }
+    let(:filename) { "asdf.txt" }
+    subject { described_class.format_file(filename) }
+
+    context 'when the file exists' do
+
+      before { File.open(filename, 'w') { |file| file.puts test_website} }
+      after { FileUtils.rm(filename) }
+
+      it 'creates a properly formatted #sites.txt file' do
+        expect { subject }.to output(/formatted/).to_stdout
+        expect(IO.read("#{PATH}/tmp/#sites.txt")).to eq("#{test_website}\n")
+      end
+    end
+
+    context 'when the file does not exist' do
+      it 'displays an error' do
+        begin
+        expect{ subject }.to output("Don't worry I'll wait!").to_stdout
+        expect { subject }.to raise_error(SystemExit)
+        rescue SystemExit # Prevent exit() call from exiting tests
+        end
+      end
+    end
+  end
+
+  describe 'get_urls' do
+    subject { described_class.get_urls }
+    # Ensure we search for the same query every time
+    before { stub_const('DEFAULT_SEARCH_QUERY', 'user_id=') }
+    let(:results) { File.readlines(SITES_TO_CHECK_PATH).map(&:strip) }
+    it 'returns the correct data' do
+      VCR.use_cassette('google_search') do
+        subject
+        expect(results.first).to eq("https://msdn.microsoft.com/en-us/library/ms181466.aspx'")
+        expect(results.last).to eq('http://www.authorcode.com/user_id-and-user_name-in-sql-server/`')
+      end
+    end
+  end
+end

--- a/whitewidow.rb
+++ b/whitewidow.rb
@@ -1,28 +1,17 @@
 #!/usr/local/env ruby
-
 require_relative 'lib/imports/constants_and_requires'
-
-#
-# Usage page, basic help page for commands
-#
-def usage_page
-  FORMAT.info("ruby #{File.basename(__FILE__)} -[SHORT-OPTS] [ARGS] --[LONG-OPTS] [ARGS]")
-  FORMAT.info("Check the README.md file for a list of flags and further information\n")
-  system('ruby whitewidow.rb --help')
-  exit
-end
 
 #
 # Append into the OPTIONS constant so that we can call the flag from the constant instead of a class
 #
 OptionParser.new do |opt|
   opt.banner="Mandatory options  : -[d|f|s] FILE|URL --[default|file|spider] FILE|URL
-Enumeration options: -[x] NUM --[dry-run|batch|run-x] NUM
-Anomity options    : -[p] IP:PORT --[rand-agent|proxy] IP:PORT
-Processing options : -[D] DORK --[sqlmap|dork] DORK
-Misc options       : -[l|b|u] --[legal|banner|beep|update]
+  Enumeration options: -[x] NUM --[dry-run|batch|run-x] NUM
+  Anomity options    : -[p] IP:PORT --[rand-agent|proxy] IP:PORT
+  Processing options : -[D] DORK --[sqlmap|dork] DORK
+  Misc options       : -[l|b|u] --[legal|banner|beep|update]
 
-" # Blank line has to be there so that the help menu looks good.
+  " # Blank line has to be there so that the help menu looks good.
   opt.on('-f FILE', '--file FILE', 'Pass a filename to scan for vulnerabilities')         { |o| OPTIONS[:file]    = o }
   opt.on('-s URL', '--spider URL', 'Spider a web page and save all the URLS')             { |o| OPTIONS[:spider]  = o }
   opt.on('-d', '--default', 'Run in default mode, scrape Google')                         { |o| OPTIONS[:default] = o }
@@ -40,124 +29,6 @@ Misc options       : -[l|b|u] --[legal|banner|beep|update]
   opt.on('--sqlmap', 'Run sqlmap through the SQL_VULN.LOG file as a bulk file')           { |o| OPTIONS[:sqlmap]  = o }
 end.parse!
 
-#
-# File formatting
-#
-def format_file
-  FORMAT.info('Writing to temporary file..')
-  if File.exists?(OPTIONS[:file])
-    file = Tempfile.new('file') # Write to a temp file
-    IO.read(OPTIONS[:file]).each_line do |line|
-      File.open(file, 'a+') { |format| format.puts(line) unless line.chomp.empty? } # Skip blank lines and whitespace
-    end
-    IO.read(file).each_line do |to_file|
-      File.open("#{PATH}/tmp/#sites.txt", 'a+') { |line| line.puts(to_file) }
-    end
-    file.unlink
-    FORMAT.info("File: #{OPTIONS[:file]}, has been formatted and saved as #sites.txt in the tmp directory.")
-  else
-    puts <<~_END_
-
-      Hey now my friend, I know you're eager, I am also, but that file #{OPTIONS[:file]}
-      either doesn't exist, or it's not in the directory you say it's in..
-
-      I'm gonna need you to go find that file, move it to the correct directory and then
-      run me again.
-
-      Don't worry I'll wait!
-         _END_
-             .yellow.bold  # Error out because the file doesn't exist
-  end
-end
-
-#
-# Get the URLS by connecting to google and scraping for the URLS on the first page
-#
-def get_urls
-  query = SETTINGS.extract_query!
-  url_arr = Array.new
-
-  File.read("#{QUERY_BLACKLIST_PATH}").each_line do |black|  # check if the search query is black listed
-    if query == black
-      FORMAT.warning("Query: #{query} is blacklisted, defaulting to random query")
-      query = File.readlines("#{PATH}/lib/lists/search_query.txt").sample  # Retry if it is
-    end
-  end
-
-  FORMAT.info("I'm searching for possible SQL vulnerable sites, using search query #{query.chomp}")
-  agent = Mechanize.new
-  if OPTIONS[:proxy]
-    agent.set_proxy(OPTIONS[:proxy].split(":").first, OPTIONS[:proxy].split(":").last)  # Set your proxy if used
-  end
-  correct_agent = SETTINGS.random_agent?
-  agent.user_agent = correct_agent
-  correct_agent == DEFAULT_USER_AGENT ? FORMAT.info("Using default user agent") :
-      FORMAT.info("Grabbed random agent: #{correct_agent}")
-  page = agent.get("http://google.com")
-  google_form = page.form('f')
-  google_form.q = "#{query}"  # Search Google for the query
-  url = agent.submit(google_form, google_form.buttons.first)
-  url.links.each do |link|
-    if link.href.to_s =~ /url.q/  # Pull the links from the search
-      str = link.href.to_s
-      str_list = str.split(%r{=|&})
-      urls = str_list[1]
-      if urls.split("/")[2].start_with?(*SKIP)  # Skip all the bad URLs
-        next
-      end
-      urls_to_log = URI.decode(urls)
-      FORMAT.success("Site found: #{urls_to_log}")
-      sleep(0.3)
-      url_arr.insert(-1, urls_to_log)
-      %w(' -- ; " /* '/* '-- "-- '; "; `).each { |err|
-        File.open("#{SITES_TO_CHECK_PATH}", 'a+') { |error_check| error_check.puts("#{urls_to_log}#{err}") } # Add sql syntax to all "="
-        MULTIPARAMS.check_for_multiple_parameters(urls_to_log, err)
-      }
-      [" AND 1=1"].each { |blind| # Temp working on adding all types of sql injection techniques
-        File.open("#{SITES_TO_CHECK_PATH}", "a+") { |blind_check| blind_check.puts("#{urls_to_log}#{blind}") }
-      }
-    end
-  end
-  FORMAT.info("I've dumped possible vulnerable sites into #{SITES_TO_CHECK_PATH}")
-end
-
-#
-# Check the sites that where found for vulnerabilities by checking if they throw a certain error
-#
-def vulnerability_check
-  OPTIONS[:default] ? file_to_read = SITES_TO_CHECK_PATH : file_to_read = FILE_FLAG_FILE_PATH
-  FORMAT.info('Forcing encoding to UTF-8') unless OPTIONS[:file]
-  IO.read("#{file_to_read}").each_line do |vuln|
-    begin
-      FORMAT.info("Parsing page for SQL syntax error: #{vuln.chomp}")
-      Timeout::timeout(10) do
-        vulns = vuln.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''}) # Force encoding to UTF-8
-        begin
-          if SETTINGS.parse("#{vulns.chomp}'", 'html', 0) =~ SQL_VULN_REGEX  # If it has the vuln regex error
-            FORMAT.site_found(vulns.chomp)
-            File.open("#{TEMP_VULN_LOG}", "a+") { |vulnerable| vulnerable.puts(vulns) }
-            sleep(0.5)
-          else
-            FORMAT.warning("URL: #{vulns.chomp} is not vulnerable, dumped to non_exploitable.txt")
-            File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |non_exploit| non_exploit.puts(vulns) }
-            sleep(0.5)
-          end
-        rescue Timeout::Error, OpenSSL::SSL::SSLError  # Timeout or SSL errors
-          FORMAT.warning("URL: #{vulns.chomp} failed to load dumped to non_exploitable.txt")
-          File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |timeout| timeout.puts(vulns) }
-          sleep(0.5)
-          next
-        end
-      end
-    rescue *LOADING_ERRORS  # site doesn't exist or this is not a valid URL
-      FORMAT.err("URL: #{vuln.chomp} failed due to an error while connecting, URL dumped to non_exploitable.txt")
-      File.open("#{NON_EXPLOITABLE_PATH}", "a+") { |error| error.puts(vuln) }
-      next
-    end
-  end
-end
-
-#
 # This case statement has to be empty or the program won't read the options constants
 begin
   case
@@ -165,7 +36,7 @@ begin
     begin
       SETTINGS.hide_banner?
       SETTINGS.show_legal?
-      get_urls
+      Whitewidow::Scanner.get_urls
       if File.size("#{SITES_TO_CHECK_PATH}") == 0
         FORMAT.warning("No sites found for search query: #{SEARCH_QUERY}. Adding query to blacklist so it won't be run again.")  # Add the query to the blacklist
         File.open("#{QUERY_BLACKLIST_PATH}", "a+") { |query| query.puts(SEARCH_QUERY) }
@@ -178,10 +49,10 @@ begin
           FORMAT.info('Sites saved to file, will not run scan now..')
           exit(0)
         else
-          vulnerability_check
+          Whitewidow::Scanner.vulnerability_check
         end
       else
-        vulnerability_check
+        Whitewidow::Scanner.vulnerability_check
       end
       File.open("#{ERROR_LOG_PATH}", 'a+') {
           |s| s.puts("No sites found with search query #{DEFAULT_SEARCH_QUERY}")
@@ -205,8 +76,8 @@ begin
       SETTINGS.hide_banner?
       SETTINGS.show_legal?
       FORMAT.info('Formatting file')
-      format_file
-      vulnerability_check
+      Whitewidow::Scanner.format_file(OPTIONS[:file])
+      Whitewidow::Scanner.vulnerability_check(file_mode: true)
       File.truncate("#{SITES_TO_CHECK_PATH}", 0)
       FORMAT.info("I'm truncating SQL_sites_to_check file back to #{File.size("#{SITES_TO_CHECK_PATH}")}")
       Copy.file("#{TEMP_VULN_LOG}", "#{SQL_VULN_SITES_LOG}")

--- a/whitewidow.rb
+++ b/whitewidow.rb
@@ -1,18 +1,22 @@
 #!/usr/local/env ruby
 require_relative 'lib/imports/constants_and_requires'
 
+def banner_message
+  [
+    "Mandatory options  : -[d|f|s] FILE|URL --[default|file|spider] FILE|URL",
+    "Enumeration options: -[x] NUM --[dry-run|batch|run-x] NUM",
+    "Anomity options    : -[p] IP:PORT --[rand-agent|proxy] IP:PORT",
+    "Processing options : -[D] DORK --[sqlmap|dork] DORK",
+    "Misc options       : -[l|b|u] --[legal|banner|beep|update]",
+    " " # Blank line for nice formatting
+  ].join("\n")
+end
 #
 # Append into the OPTIONS constant so that we can call the flag from the constant instead of a class
 #
 ARGV << '-h' if ARGV.empty? # Display help dialog if no flags are passed
 OptionParser.new do |opt|
-  opt.banner="Mandatory options  : -[d|f|s] FILE|URL --[default|file|spider] FILE|URL
-  Enumeration options: -[x] NUM --[dry-run|batch|run-x] NUM
-  Anomity options    : -[p] IP:PORT --[rand-agent|proxy] IP:PORT
-  Processing options : -[D] DORK --[sqlmap|dork] DORK
-  Misc options       : -[l|b|u] --[legal|banner|beep|update]
-
-  " # Blank line has to be there so that the help menu looks good.
+  opt.banner = banner_message
   opt.on('-f FILE', '--file FILE', 'Pass a filename to scan for vulnerabilities')         { |o| OPTIONS[:file]    = o }
   opt.on('-s URL', '--spider URL', 'Spider a web page and save all the URLS')             { |o| OPTIONS[:spider]  = o }
   opt.on('-d', '--default', 'Run in default mode, scrape Google')                         { |o| OPTIONS[:default] = o }


### PR DESCRIPTION
### Why?
As Whitewidow grows, the code will become harder to maintain and harder to manually test to ensure no new bugs have been introduced.

By adding tests, separating the code into classes with a single responsibility, and reducing coupling between said classes, changes will be easier and safer to make.

### What Changed?
* Extracted `Scanner` logic out to a separate module. `lib/whitewidow/scanner.rb`
  - This includes all methods not related to the OptionParser or the main case statement that was in `whitewidow.rb`
  - These changes are a preliminary attempt to move towards OOP best practices

* Introduced RSpec testing framework
  - Wrote tests for new `Scanner` module that tests a good portion of the primary logic

* Added Webmock and VCR to ensure tests are not doing _live_ scans