### PR TITLE
Feature/remove tmp file dependency

### DIFF
--- a/lib/helpers/file_helper.rb
+++ b/lib/helpers/file_helper.rb
@@ -1,0 +1,31 @@
+# Allows files to be opened without having to write an explicit check to see if the file or directory exists
+class FileHelper
+  class << self
+    def open_or_create(filename)
+      unless File.exist?(filename)
+        directory = directory_path(filename)
+        create_directory(directory) unless directory_exists?(directory)
+        create_file(filename)
+      end
+      filename
+    end
+
+    private
+
+    def create_directory(dir)
+      FileUtils.mkdir_p(dir)
+    end
+
+    def create_file(filename)
+      FileUtils.touch(filename)
+    end
+
+    def directory_path(filename)
+      File.dirname(filename)
+    end
+
+    def directory_exists?(dir)
+      File.directory?(dir)
+    end
+  end
+end

--- a/lib/imports/constants_and_requires.rb
+++ b/lib/imports/constants_and_requires.rb
@@ -16,6 +16,7 @@ require 'net/http'
 require 'ipaddr'
 
 # Created libraries that are relied on for the program to run
+require_relative '../../lib/helpers/file_helper'
 require_relative '../../lib/modules/core/format'
 require_relative '../../lib/misc/legal'
 require_relative '../../lib/misc/banner'
@@ -95,28 +96,28 @@ CREATE_ISSUE = Template::Templates.new
 SQLMAP_PATH = "#{PATH}/lib/modules/core/tools/sqlmap/sqlmap.py"
 
 # Path to the error log for fatal errors
-ERROR_LOG_PATH = "#{PATH}/log/error_log.LOG"
+ERROR_LOG_PATH = FileHelper.open_or_create("#{PATH}/log/error_log.LOG")
 
 # Path to the SQL_VULN.LOG file
-SQL_VULN_SITES_LOG = "#{PATH}/log/SQL_VULN.LOG"
+SQL_VULN_SITES_LOG = FileHelper.open_or_create("#{PATH}/log/SQL_VULN.LOG")
 
 # Path to temp vuln log
-TEMP_VULN_LOG = "#{PATH}/tmp/SQL_VULN.txt"
+TEMP_VULN_LOG = FileHelper.open_or_create("#{PATH}/tmp/SQL_VULN.txt")
 
 # Path to the sql_sites_to_check file
-SITES_TO_CHECK_PATH = "#{PATH}/tmp/SQL_sites_to_check.txt"
+SITES_TO_CHECK_PATH = FileHelper.open_or_create("#{PATH}/tmp/SQL_sites_to_check.txt")
 
 # Path to the search query blacklist
-QUERY_BLACKLIST_PATH = "#{PATH}/log/query_blacklist"
+QUERY_BLACKLIST_PATH = FileHelper.open_or_create("#{PATH}/log/query_blacklist")
 
 # Path to non_exploitable.txt
-NON_EXPLOITABLE_PATH = "#{PATH}/log/non_exploitable.txt"
+NON_EXPLOITABLE_PATH = FileHelper.open_or_create("#{PATH}/log/non_exploitable.txt")
 
 # Path to the file when the file flag is used
-FILE_FLAG_FILE_PATH = "#{PATH}/tmp/#sites.txt"
+FILE_FLAG_FILE_PATH = FileHelper.open_or_create("#{PATH}/tmp/#sites.txt")
 
 # Blackwidow log file path
-BLACKWIDOW_LOG = "#{PATH}/tmp/blackwidow_log.txt"
+BLACKWIDOW_LOG = FileHelper.open_or_create("#{PATH}/tmp/blackwidow_log.txt")
 
 # Issue path
 ISSUE_TEMPLATE_PATH = "#{PATH}/tmp/issues"

--- a/lib/whitewidow/scanner.rb
+++ b/lib/whitewidow/scanner.rb
@@ -14,7 +14,7 @@ module Whitewidow
             File.open(file, 'a+') { |format| format.puts(line) unless line.chomp.empty? } # Skip blank lines and whitespace
           end
           IO.read(file).each_line do |to_file|
-            File.open("#{PATH}/tmp/#sites.txt", 'a+') { |line| line.puts(to_file) }
+            File.open(FILE_FLAG_FILE_PATH, 'a+') { |line| line.puts(to_file) }
           end
           file.unlink
           FORMAT.info("File: #{user_file}, has been formatted and saved as #sites.txt in the tmp directory.")

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -10,7 +10,7 @@ describe FileHelper do
       before { FileUtils.touch(filename) }
 
       it 'returns the filename and the file can be opened' do
-        expect{subject}.to_not raise_error
+        expect{ subject }.to_not raise_error
       end
     end
 

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe FileHelper do
+  describe 'open_or_create' do
+    subject { File.open(FileHelper.open_or_create(filename)) }
+    after { FileUtils.rm(filename) }
+
+    context 'when the file exists' do
+      let(:filename) { 'testing_file' }
+      before { FileUtils.touch(filename) }
+
+      it 'returns the filename and the file can be opened' do
+        expect{subject}.to_not raise_error
+      end
+    end
+
+    context 'when the file does not exist' do
+      let(:filename) { File.join('tmp', 'test_directory', 'test_file') }
+
+      it 'creates the file and the file can be opened' do
+        expect{ File.open(filename) }.to raise_error
+        expect{ subject }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,8 @@ end
 
 RSpec.configure do |config|
   config.after(:each) do
-    # TODO: Remove dependency on tmp directory's existence so we can just FileUtils.rm_rf('tmp')
     File.truncate(SITES_TO_CHECK_PATH, 0)
-    File.truncate('tmp/#sites.txt', 0)
+    File.truncate(FILE_FLAG_FILE_PATH , 0)
   end
 
   ### Silence stdout during tests ###

--- a/spec/whitewidow/scanner_spec.rb
+++ b/spec/whitewidow/scanner_spec.rb
@@ -36,8 +36,8 @@ describe Whitewidow::Scanner do
     it 'returns the correct data' do
       VCR.use_cassette('google_search') do
         subject
-        expect(results.first).to eq("https://msdn.microsoft.com/en-us/library/ms181466.aspx'")
-        expect(results.last).to eq('http://www.authorcode.com/user_id-and-user_name-in-sql-server/`')
+        expect(results.first).to include("https://msdn.microsoft.com/en-us/library/ms181466.aspx")
+        expect(results.last).to include('http://www.authorcode.com/user_id-and-user_name-in-sql-server/')
       end
     end
   end

--- a/spec/whitewidow/scanner_spec.rb
+++ b/spec/whitewidow/scanner_spec.rb
@@ -13,7 +13,7 @@ describe Whitewidow::Scanner do
 
       it 'creates a properly formatted #sites.txt file' do
         expect { subject }.to output(/formatted/).to_stdout
-        expect(IO.read("#{PATH}/tmp/#sites.txt")).to eq("#{test_website}\n")
+        expect(IO.read(FILE_FLAG_FILE_PATH)).to eq("#{test_website}\n")
       end
     end
 


### PR DESCRIPTION
### Why?
If a file doesn't exist, it should just get created instead of causing an error.

### What Changed?
* Created `FileHelper` class with `open_or_create` method that will create a file and all directories leading to it if they don't exist
* This helper can be used anywhere a filename is normally used to add automatic file creation
* Changed declared constants (in the `tmp` and `log` directories) to use this new method.
* Added tests for `FileHelper` class
* Improved flexibility of `Scanner` test